### PR TITLE
Fix/remove fuzzy url

### DIFF
--- a/hyper_resource.gemspec
+++ b/hyper_resource.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.files    = Dir['lib/**/*']
   s.license  = 'MIT'
-  s.has_rdoc = true
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 1.8.7'
@@ -26,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'uri_template', '>= 0.5.2'
   s.add_dependency 'faraday',      '>= 0.8.6'
   s.add_dependency 'json'
-  s.add_dependency 'fuzzyurl', '0.2.2'
 
   s.add_development_dependency 'rake',      '>= 10.0.4'
   s.add_development_dependency 'minitest',  '>= 4.7.0'

--- a/lib/hyper_resource/configuration.rb
+++ b/lib/hyper_resource/configuration.rb
@@ -1,5 +1,4 @@
 require 'uri'
-require 'fuzzyurl'
 
 class HyperResource
 
@@ -87,26 +86,16 @@ class HyperResource
     ## Sets a key and value pair, using the given URL as the basis of the
     ## hostmask.  Path, query, and fragment are ignored.
     def set_for_url(url, key, value)
-      furl = FuzzyURL.new(url || '*')
-      furl.path = nil
-      furl.query = nil
-      furl.fragment = nil
-      set(furl.to_s, key, value)
+      set(URI.parse(url || "").host, key, value)
     end
 
 
     ## Returns hostmasks from our config which match the given url.
     def matching_masks_for_url(url)
-      url = url.to_s
-      return ['*'] if !url || cfg.keys.count == 1
-      @masks ||= {} ## key = mask string, value = FuzzyURL
-      cfg.keys.each {|key| @masks[key] ||= FuzzyURL.new(key) }
-
-      ## Test for matches, and sort by score.
-      scores = {}
-      cfg.keys.each {|key| scores[key] = @masks[key].match(url) }
-      scores = Hash[ scores.select{|k,v| v} ] # remove nils
-      scores.keys.sort_by{|k| [-scores[k], -k.length]} ## TODO length is cheesy
+      host = URI.parse(url || "").host
+      cfg.keys.filter_map do |h, c|
+        c if host == h || h.nil?
+      end
     end
 
   private

--- a/lib/hyper_resource/configuration.rb
+++ b/lib/hyper_resource/configuration.rb
@@ -93,9 +93,7 @@ class HyperResource
     ## Returns hostmasks from our config which match the given url.
     def matching_masks_for_url(url)
       host = URI.parse(url || "").host
-      cfg.keys.filter_map do |h, c|
-        c if host == h || h.nil?
-      end
+      cfg.keys & ["*", host]
     end
 
   private

--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -129,7 +129,7 @@ class HyperResource
         ## Adding default_attributes to URL query params is not automatic
         uri = URI.parse(self.url || '')
         query = CGI.parse(uri.query || '')
-        str = (self.resource.default_attributes || {}).merge(query)
+        str = URI.encode_www_form((self.resource.default_attributes || {}).merge(query))
         uri.query = str.empty? ? nil : str
         faraday_connection.get(uri.to_s)
       end

--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -127,15 +127,11 @@ class HyperResource
       ## Does not parse the response as a `HyperResource` object.
       def get_response
         ## Adding default_attributes to URL query params is not automatic
-        url = FuzzyURL.new(self.url || '')
-        query_str = url[:query] || ''
-        query_attrs = Hash[ query_str.split('&').map{|p| p.split('=')} ]
-        attrs = (self.resource.default_attributes || {}).merge(query_attrs)
-        attrs_str = attrs.inject([]){|pairs,(k,v)| pairs<<"#{k}=#{v}"}.join('&')
-        if attrs_str != ''
-          url = FuzzyURL.new(url.to_hash.merge(:query => attrs_str))
-        end
-        faraday_connection.get(url.to_s)
+        uri = URI.parse(self.url || '')
+        query = CGI.parse(uri.query || '')
+        str = (self.resource.default_attributes || {}).merge(query)
+        uri.query = str.empty? ? nil : str
+        faraday_connection.get(uri.to_s)
       end
 
       ## By default, calls +post+ with the given arguments. Override to


### PR DESCRIPTION
Remove the fuzzy url dependency, so we can update to ruby 3.4.  For https://github.com/PRX/feeder.prx.org/pull/1248.